### PR TITLE
WIP: Linux fixes

### DIFF
--- a/doom/build.gradle
+++ b/doom/build.gradle
@@ -33,6 +33,7 @@ android {
     buildToolsVersion '28.0.3'
 
     defaultConfig {
+        ndkVersion "21.3.6528147"
         minSdkVersion 21
         targetSdkVersion 26
         versionCode 19

--- a/doom/src/main/jni/Android.mk
+++ b/doom/src/main/jni/Android.mk
@@ -9,7 +9,7 @@ include $(TOP_DIR)/AudioLibs_OpenTouch/libsndfile-android/jni/Android.mk
 include $(TOP_DIR)/AudioLibs_OpenTouch/libmpg123/Android.mk
 include $(TOP_DIR)/AudioLibs_OpenTouch/fluidsynth-lite/src/Android.mk
 include $(TOP_DIR)/AudioLibs_OpenTouch/openal/Android.mk
-include $(TOP_DIR)/AudioLibs_OpenTouch/FMOD_Studio/Android.mk
+include $(TOP_DIR)/AudioLibs_OpenTouch/FMOD_studio/Android.mk
 include $(TOP_DIR)/AudioLibs_OpenTouch/android_external_flac/Android.mk
 
 include $(TOP_DIR)/jpeg8d/Android.mk


### PR DESCRIPTION
Various fixes to compile on linux.
The questionable change is specifying ndk version explicitly, because the binary stripping gradle task will fail unless the currently installed ndk version is specified. I'm using ndk r21d, which is the last r21 release.

I suppose build.sh and diff.sh can be removed too, since now there's no patches (or I could rewrite build.sh to check for build requirements and run ndk build and gradle assembleRelease).